### PR TITLE
fix: Use c_char where appropriate

### DIFF
--- a/rust/nix-expr/src/eval_state.rs
+++ b/rust/nix-expr/src/eval_state.rs
@@ -284,7 +284,7 @@ impl EvalState {
         let n = unsafe { check_call!(raw::get_attrs_size(&mut self.context, v.raw_ptr())) }?;
         let mut attrs = Vec::with_capacity(n as usize);
         for i in 0..n {
-            let cstr_ptr: *const u8 = unsafe {
+            let cstr_ptr: *const c_char = unsafe {
                 check_call!(raw::get_attr_name_byidx(
                     &mut self.context,
                     v.raw_ptr(),

--- a/rust/nix-flake/src/lib.rs
+++ b/rust/nix-flake/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{ffi::CString, ptr::NonNull};
+use std::{ffi::CString, os::raw::c_char, ptr::NonNull};
 
 use anyhow::{Context as _, Result};
 use nix_c_raw as raw;
@@ -87,7 +87,7 @@ impl FlakeReferenceParseFlags {
             context::check_call!(raw::flake_reference_parse_flags_set_base_directory(
                 &mut ctx,
                 self.ptr.as_ptr(),
-                base_directory.as_ptr() as *const u8,
+                base_directory.as_ptr() as *const c_char,
                 base_directory.len()
             ))
         }?;
@@ -125,7 +125,7 @@ impl FlakeReference {
                 fetch_settings.raw_ptr(),
                 flake_settings.ptr,
                 flags.ptr.as_ptr(),
-                reference.as_ptr() as *const u8,
+                reference.as_ptr() as *const c_char,
                 reference.len(),
                 // pointer to ptr
                 &mut ptr,

--- a/rust/nix-util/src/context.rs
+++ b/rust/nix-util/src/context.rs
@@ -1,5 +1,6 @@
 use anyhow::{bail, Result};
 use nix_c_raw as raw;
+use std::os::raw::c_char;
 use std::ptr::null_mut;
 use std::ptr::NonNull;
 
@@ -50,7 +51,7 @@ impl Context {
             raw::set_err_msg(
                 self.inner.as_ptr(),
                 raw::err_NIX_OK,
-                b"\0".as_ptr() as *const u8,
+                b"\0".as_ptr() as *const c_char,
             );
         }
     }


### PR DESCRIPTION
This builds on the previous commit to make it compatible with the currently locked build configuration.
Does it still work for your config, @RossComputerGuy?

This PR targets
- https://github.com/nixops4/nixops4/pull/118