### PR TITLE
feat: add derivation functions to nix_store

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1733328505,
-        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
@@ -98,48 +98,40 @@
         ]
       },
       "locked": {
-        "lastModified": 1733312601,
-        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
-        "type": "github"
+        "lastModified": 1748821116,
+        "narHash": "sha256-F82+gS044J1APL0n4hH50GYdPRv/5JWm34oCJYmVKdE=",
+        "rev": "49f0870db23e8c1ca0b5259734a02cd9e1e371a1",
+        "revCount": 377,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/hercules-ci/flake-parts/0.1.377%2Brev-49f0870db23e8c1ca0b5259734a02cd9e1e371a1/01972f28-554a-73f8-91f4-d488cc502f08/source.tar.gz"
       },
       "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://flakehub.com/f/hercules-ci/flake-parts/0.1"
       }
     },
     "git-hooks-nix": {
       "inputs": {
-        "flake-compat": [
-          "nix"
-        ],
+        "flake-compat": "flake-compat",
         "gitignore": [
           "nix"
         ],
         "nixpkgs": [
           "nix",
           "nixpkgs"
-        ],
-        "nixpkgs-stable": [
-          "nix",
-          "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1734279981,
-        "narHash": "sha256-NdaCraHPp8iYMWzdXAt5Nv6sA3MUzlCiGiR586TCwo0=",
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "aa9f40c906904ebd83da78e7f328cd8aeaeae785",
-        "type": "github"
+        "lastModified": 1747372754,
+        "narHash": "sha256-2Y53NGIX2vxfie1rOW0Qb86vjRZ7ngizoo+bnXU9D9k=",
+        "rev": "80479b6ec16fefd9c1db3ea13aeb038c60530f46",
+        "revCount": 1026,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/cachix/git-hooks.nix/0.1.1026%2Brev-80479b6ec16fefd9c1db3ea13aeb038c60530f46/0196d79a-1b35-7b8e-a021-c894fb62163d/source.tar.gz"
       },
       "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://flakehub.com/f/cachix/git-hooks.nix/0.1.941"
       }
     },
     "mk-naked-shell": {
@@ -160,7 +152,6 @@
     },
     "nix": {
       "inputs": {
-        "flake-compat": "flake-compat",
         "flake-parts": "flake-parts_2",
         "git-hooks-nix": "git-hooks-nix",
         "nixpkgs": [
@@ -170,17 +161,16 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1758304615,
-        "narHash": "sha256-ZAammm/As5XUTMKx4UX1ShuKKDqi0J6epHvkLoEE9kQ=",
-        "owner": "NixOS",
-        "repo": "nix",
-        "rev": "9237e52ebbb445c6c905e7677e4235d3baa5f6d1",
+        "lastModified": 1759345327,
+        "narHash": "sha256-JwCtMONVspYl/EA++ZpOoKwIhLazoOGMApHes5rO2tA=",
+        "owner": "DeterminateSystems",
+        "repo": "nix-src",
+        "rev": "1f8e87175490ff41ad470622c3b830a7bfc840b4",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "pull/14025/head",
-        "repo": "nix",
+        "owner": "DeterminateSystems",
+        "repo": "nix-src",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     flake-parts.url = "github:hercules-ci/flake-parts";
-    nix.url = "github:NixOS/nix?ref=pull/14025/head";
+    nix.url = "github:DeterminateSystems/nix-src";
     nix.inputs.nixpkgs.follows = "nixpkgs";
     nix-cargo-integration.url = "github:yusdacra/nix-cargo-integration";
     nix-cargo-integration.inputs.nixpkgs.follows = "nixpkgs";

--- a/rust/nix-store/src/drv.rs
+++ b/rust/nix-store/src/drv.rs
@@ -1,0 +1,76 @@
+use anyhow::Result;
+use std::ptr::NonNull;
+
+use nix_c_raw as raw;
+use nix_util::context::Context;
+use nix_util::string_return::{callback_get_result_string, callback_get_result_string_data};
+use nix_util::{check_call, result_string_init};
+
+pub struct Derivation {
+    raw: NonNull<raw::derivation>,
+    /* An error context to reuse. This way we don't have to allocate them for each store operation. */
+    context: Context,
+}
+impl Derivation {
+    /// This is a low level function that you shouldn't have to call unless you are developing the Nix bindings.
+    ///
+    /// Construct a new `Derivation` by first cloning the C derivation.
+    ///
+    /// # Safety
+    ///
+    /// This does not take ownership of the C store path, so it should be a borrowed pointer, or you should free it.
+    pub unsafe fn new_raw_clone(raw: NonNull<raw::derivation>) -> Self {
+        Self::new_raw(
+            NonNull::new(raw::derivation_clone(raw.as_ptr()))
+                .or_else(|| panic!("nix_derivation_clone returned a null pointer"))
+                .unwrap(),
+        )
+    }
+
+    /// This is a low level function that you shouldn't have to call unless you are developing the Nix bindings.
+    ///
+    /// Takes ownership of a C `nix_derivation`. It will be freed when the `Derivation` is dropped.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the provided `NonNull<raw::derivation>` is valid and that the ownership
+    /// semantics are correctly followed. The `raw` pointer must not be used after being passed to this function.
+    pub unsafe fn new_raw(raw: NonNull<raw::derivation>) -> Self {
+        Derivation {
+            raw,
+            context: Context::new(),
+        }
+    }
+
+    /// This is a low level function that you shouldn't have to call unless you are developing the Nix bindings.
+    ///
+    /// Get a pointer to the underlying Nix C API derivation.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because it returns a raw pointer. The caller must ensure that the pointer is not used beyond the lifetime of this `Derivation`.
+    pub unsafe fn as_ptr(&self) -> *mut nix_c_raw::derivation {
+        self.raw.as_ptr()
+    }
+
+    #[doc(alias = "nix_derivation_to_json")]
+    pub fn to_json_string(&mut self) -> Result<String> {
+        let mut r = result_string_init!();
+        unsafe {
+            check_call!(raw::derivation_to_json(
+                &mut self.context,
+                self.raw.as_ptr(),
+                Some(callback_get_result_string),
+                callback_get_result_string_data(&mut r)
+            ))
+        }?;
+        r
+    }
+}
+impl Drop for Derivation {
+    fn drop(&mut self) {
+        unsafe {
+            raw::derivation_free(self.as_ptr());
+        }
+    }
+}

--- a/rust/nix-store/src/lib.rs
+++ b/rust/nix-store/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod drv;
 pub mod path;
 pub mod store;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a derivation object with JSON conversion.
  - Load derivations from a store path or JSON, add them to the store, compute derivation outputs, and build multiple paths; results returned as maps.
  - Query path metadata.

- Chores
  - Updated the Nix flake input source to the DeterminateSystems/nix-src reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->