### PR TITLE
feat: nix_store::store add get_fs_closure function

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,15 +170,16 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1756762578,
-        "narHash": "sha256-JpSWFjOgPWeWb5bb+HMMGR+Q0dOH7nl2t4WgyBVaWx8=",
+        "lastModified": 1758304615,
+        "narHash": "sha256-ZAammm/As5XUTMKx4UX1ShuKKDqi0J6epHvkLoEE9kQ=",
         "owner": "NixOS",
         "repo": "nix",
-        "rev": "ab095c029c7deef98b99c5249c09fe9a8a095800",
+        "rev": "9237e52ebbb445c6c905e7677e4235d3baa5f6d1",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "pull/14025/head",
         "repo": "nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     flake-parts.url = "github:hercules-ci/flake-parts";
-    nix.url = "github:NixOS/nix";
+    nix.url = "github:NixOS/nix?ref=pull/14025/head";
     nix.inputs.nixpkgs.follows = "nixpkgs";
     nix-cargo-integration.url = "github:yusdacra/nix-cargo-integration";
     nix-cargo-integration.inputs.nixpkgs.follows = "nixpkgs";

--- a/rust/nix-expr/src/eval_state.rs
+++ b/rust/nix-expr/src/eval_state.rs
@@ -284,7 +284,7 @@ impl EvalState {
         let n = unsafe { check_call!(raw::get_attrs_size(&mut self.context, v.raw_ptr())) }?;
         let mut attrs = Vec::with_capacity(n as usize);
         for i in 0..n {
-            let cstr_ptr: *const i8 = unsafe {
+            let cstr_ptr: *const u8 = unsafe {
                 check_call!(raw::get_attr_name_byidx(
                     &mut self.context,
                     v.raw_ptr(),

--- a/rust/nix-expr/src/eval_state.rs
+++ b/rust/nix-expr/src/eval_state.rs
@@ -284,7 +284,7 @@ impl EvalState {
         let n = unsafe { check_call!(raw::get_attrs_size(&mut self.context, v.raw_ptr())) }?;
         let mut attrs = Vec::with_capacity(n as usize);
         for i in 0..n {
-            let cstr_ptr: *const u8 = unsafe {
+            let cstr_ptr: *const c_char = unsafe {
                 check_call!(raw::get_attr_name_byidx(
                     &mut self.context,
                     v.raw_ptr(),

--- a/rust/nix-flake/src/lib.rs
+++ b/rust/nix-flake/src/lib.rs
@@ -87,7 +87,7 @@ impl FlakeReferenceParseFlags {
             context::check_call!(raw::flake_reference_parse_flags_set_base_directory(
                 &mut ctx,
                 self.ptr.as_ptr(),
-                base_directory.as_ptr() as *const i8,
+                base_directory.as_ptr() as *const u8,
                 base_directory.len()
             ))
         }?;
@@ -125,7 +125,7 @@ impl FlakeReference {
                 fetch_settings.raw_ptr(),
                 flake_settings.ptr,
                 flags.ptr.as_ptr(),
-                reference.as_ptr() as *const i8,
+                reference.as_ptr() as *const u8,
                 reference.len(),
                 // pointer to ptr
                 &mut ptr,

--- a/rust/nix-flake/src/lib.rs
+++ b/rust/nix-flake/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{ffi::CString, ptr::NonNull};
+use std::{ffi::CString, os::raw::c_char, ptr::NonNull};
 
 use anyhow::{Context as _, Result};
 use nix_c_raw as raw;
@@ -87,7 +87,7 @@ impl FlakeReferenceParseFlags {
             context::check_call!(raw::flake_reference_parse_flags_set_base_directory(
                 &mut ctx,
                 self.ptr.as_ptr(),
-                base_directory.as_ptr() as *const u8,
+                base_directory.as_ptr() as *const c_char,
                 base_directory.len()
             ))
         }?;
@@ -125,7 +125,7 @@ impl FlakeReference {
                 fetch_settings.raw_ptr(),
                 flake_settings.ptr,
                 flags.ptr.as_ptr(),
-                reference.as_ptr() as *const u8,
+                reference.as_ptr() as *const c_char,
                 reference.len(),
                 // pointer to ptr
                 &mut ptr,

--- a/rust/nix-util/src/context.rs
+++ b/rust/nix-util/src/context.rs
@@ -50,7 +50,7 @@ impl Context {
             raw::set_err_msg(
                 self.inner.as_ptr(),
                 raw::err_NIX_OK,
-                b"\0".as_ptr() as *const i8,
+                b"\0".as_ptr() as *const u8,
             );
         }
     }

--- a/rust/nix-util/src/context.rs
+++ b/rust/nix-util/src/context.rs
@@ -1,5 +1,6 @@
 use anyhow::{bail, Result};
 use nix_c_raw as raw;
+use std::os::raw::c_char;
 use std::ptr::null_mut;
 use std::ptr::NonNull;
 
@@ -50,7 +51,7 @@ impl Context {
             raw::set_err_msg(
                 self.inner.as_ptr(),
                 raw::err_NIX_OK,
-                b"\0".as_ptr() as *const u8,
+                b"\0".as_ptr() as *const c_char,
             );
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a capability to compute and return the filesystem closure for a store path, enabling more complete dependency/deriver queries in tooling.
- Bug Fixes
  - Improved platform compatibility and stability by standardizing C string handling across components.
- Refactor
  - Aligned internal FFI usage to use consistent character types without changing behavior.
- Chores
  - Updated the Nix input to a specific upstream revision for reproducible builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->