### PR TITLE
nix-flake: add get_path for locked flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -161,11 +161,11 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1759345327,
-        "narHash": "sha256-JwCtMONVspYl/EA++ZpOoKwIhLazoOGMApHes5rO2tA=",
+        "lastModified": 1762723967,
+        "narHash": "sha256-QrkPq3v5Px8rdl4+FoONC8FwiIw48Jrgk4cbucbyhyw=",
         "owner": "DeterminateSystems",
         "repo": "nix-src",
-        "rev": "1f8e87175490ff41ad470622c3b830a7bfc840b4",
+        "rev": "42a402fc873de408a4c00017b134759093be2d8c",
         "type": "github"
       },
       "original": {

--- a/rust/nix-flake/src/lib.rs
+++ b/rust/nix-flake/src/lib.rs
@@ -251,6 +251,24 @@ impl LockedFlake {
             Ok(nix_expr::value::__private::raw_value_new(r))
         }
     }
+
+    /// Reads a file out of the Flake
+    pub fn read_path(&self, path: &str) -> Result<String> {
+        let mut ctx = Context::new();
+        let mut r = result_string_init!();
+        unsafe {
+            context::check_call!(raw::locked_flake_read_path(
+                &mut ctx,
+                self.ptr.as_ptr(),
+                CString::new(path)
+                    .context("Failed to create CString for path")?
+                    .as_ptr(),
+                Some(callback_get_result_string),
+                callback_get_result_string_data(&mut r)
+            ))
+        }?;
+        r
+    }
 }
 
 #[cfg(test)]

--- a/rust/nix-store/src/store.rs
+++ b/rust/nix-store/src/store.rs
@@ -67,6 +67,7 @@ lazy_static! {
 }
 
 unsafe extern "C" fn callback_get_result_store_path_set(
+    _context: *mut raw::c_context,
     user_data: *mut std::os::raw::c_void,
     store_path: *const raw::StorePath,
 ) {

--- a/rust/nix-util/src/context.rs
+++ b/rust/nix-util/src/context.rs
@@ -144,7 +144,7 @@ mod tests {
             raw::set_err_msg(
                 ctx_ptr,
                 raw::err_NIX_ERR_UNKNOWN.try_into().unwrap(),
-                b"dummy error message\0".as_ptr() as *const i8,
+                b"dummy error message\0".as_ptr() as *const std::os::raw::c_char,
             );
         }
     }

--- a/rust/nix-util/src/string_return.rs
+++ b/rust/nix-util/src/string_return.rs
@@ -75,7 +75,7 @@ mod tests {
     #[test]
     fn test_callback_result_string() {
         let mut ret: Result<String> = result_string_init!();
-        let start: *const std::os::raw::c_char = b"helloGARBAGE".as_ptr() as *const i8;
+        let start = b"helloGARBAGE".as_ptr() as *const std::os::raw::c_char;
         let n: std::os::raw::c_uint = 5;
         let user_data: *mut std::os::raw::c_void = callback_get_result_string_data(&mut ret);
         unsafe {


### PR DESCRIPTION
Depends on https://github.com/DeterminateSystems/nix-src/pull/244

This adds the ability to get the path of a locked Flake.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Type annotation corrections for improved consistency and type safety.

* **Chores**
  * Internal infrastructure and API updates for enhanced system compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->